### PR TITLE
Add HTTP/2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ a node-style callback. The config object must have at minimum an `http` or
 | `https.*`                | Any other properties supported by [https.createServer](https://nodejs.org/dist/latest-v8.x/docs/api/https.html#https_https_createserver_options_requestlistener) can be added to the https object, except `secureProtocol` and `secureOptions` which are set to recommended values.   |
 | `http2`                  | Optional object. If present, an HTTP/2 server is started. You may start multiple HTTP/2 servers by passing an array of objects                                                                                                                                                        |
 | `http2.allowHTTP1`       | Enable [ALPN negotiation] allowing support for both HTTPS and HTTP/2 on the same socket.                                                                                                                                                                                              |
+| `http2.*`                | Any other properties supported by [http2.createSecureServer](https://nodejs.org/dist/latest-v8.x/docs/api/http2.html#http2_http2_createsecureserver_options_onrequesthandler).                                                                                                        |
 
 If successful, the `create-servers` callback is passed an object with the
 following properties:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ a node-style callback. The config object must have at minimum an `http` or
 | `https.sni`              | See [SNI Support](#sni-support).                                                                                                                                                                                                                                                      |
 | `https.handler`          | Handler for HTTPS requests. If you want to share a handler with all servers, use a top-level `handler` config property instead.                                                                                                                                                       |
 | `https.*`                | Any other properties supported by [https.createServer](https://nodejs.org/dist/latest-v8.x/docs/api/https.html#https_https_createserver_options_requestlistener) can be added to the https object, except `secureProtocol` and `secureOptions` which are set to recommended values.   |
+| `http2`                  | Optional object. If present, an HTTP/2 server is started. You may start multiple HTTP/2 servers by passing an array of objects                                                                                                                                                        |
+| `http2.allowHTTP1`       | Enable [ALPN negotiation] allowing support for both HTTPS and HTTP/2 on the same socket.                                                                                                                                                                                              |
 
 If successful, the `create-servers` callback is passed an object with the
 following properties:
@@ -286,3 +288,4 @@ var servers = createServers(
 [article]: https://certsimple.com/blog/a-plus-node-js-ssl
 [iojs]: https://github.com/iojs/io.js
 [ciphers]: https://iojs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener
+[ALPN negotiation]: https://nodejs.org/api/http2.html#http2_alpn_negotiation

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ a node-style callback. The config object must have at minimum an `http` or
 | `https.*`                | Any other properties supported by [https.createServer](https://nodejs.org/dist/latest-v8.x/docs/api/https.html#https_https_createserver_options_requestlistener) can be added to the https object, except `secureProtocol` and `secureOptions` which are set to recommended values.   |
 | `http2`                  | Optional object. If present, an HTTP/2 server is started. You may start multiple HTTP/2 servers by passing an array of objects                                                                                                                                                        |
 | `http2.allowHTTP1`       | Enable [ALPN negotiation] allowing support for both HTTPS and HTTP/2 on the same socket.                                                                                                                                                                                              |
-| `http2.*`                | Any other properties supported by [http2.createSecureServer](https://nodejs.org/dist/latest-v8.x/docs/api/http2.html#http2_http2_createsecureserver_options_onrequesthandler).                                                                                                        |
+| `http2.*`                | The same `https` security options are allowed, as well as any other properties supported by [http2.createSecureServer](https://nodejs.org/dist/latest-v8.x/docs/api/http2.html#http2_http2_createsecureserver_options_onrequesthandler).                                              |
 
 If successful, the `create-servers` callback is passed an object with the
 following properties:

--- a/index.js
+++ b/index.js
@@ -8,8 +8,6 @@
  */
 
 var fs = require('fs'),
-  http = require('http'),
-  https = require('https'),
   tls = require('tls'),
   path = require('path'),
   constants = require('constants'),
@@ -292,7 +290,7 @@ async function createHttp(httpConfig, log) {
   }
 
   return await new Promise(resolve => {
-    var server = http.createServer(httpConfig.handler),
+    var server = require('http').createServer(httpConfig.handler),
       timeout = httpConfig.timeout,
       port = httpConfig.port,
       args;
@@ -361,7 +359,7 @@ async function createHttps(ssl, log, h2) {
     if(h2) {
       server = require('http2').createSecureServer(finalHttpsOptions, ssl.handler)
     } else {
-      server = https.createServer(finalHttpsOptions, ssl.handler);
+      server = require('https').createServer(finalHttpsOptions, ssl.handler);
     }
 
     if (typeof timeout === 'number') server.setTimeout(timeout);

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function normalizeOptions(options) {
   const http2 = normalizeHttpsOptions(options.http2, options);
 
   if (!http && !https && !http2) {
-    throw new Error('http and/or https are required options');
+    throw new Error('http, https, and/or http2 are required options');
   }
 
   return {

--- a/test/create-servers-test.js
+++ b/test/create-servers-test.js
@@ -10,6 +10,7 @@ var path = require('path'),
   url = require('url'),
   http = require('http'),
   https = require('https'),
+  http2 = require('http2'),
   { promisify } = require('util'),
   test = require('tape'),
   sinon = require('sinon'),
@@ -17,6 +18,8 @@ var path = require('path'),
   createServers = require('../');
 
 const createServersAsync = promisify(createServers);
+
+const { HTTP2_HEADER_PATH } = http2.constants;
 
 const ca = fs.readFileSync(path.join(__dirname, './fixtures/example-ca-cert.pem'));
 
@@ -48,6 +51,74 @@ async function download(httpsURL) {
     });
     req.once('error', reject);
   });
+}
+
+//
+// Request and download response from a URL using HTTP/2
+//
+async function download2(httpsURL) {
+  return new Promise((resolve, reject) => {
+    const clientSession = http2.connect(httpsURL);
+    const fail = results => {
+      clientSession.close();
+      reject(results);
+    };
+
+    const req = clientSession.request({ [HTTP2_HEADER_PATH]: '/' });
+    req.on('response', () => {
+      const chunks = [];
+      req
+        .on('data', chunk => chunks.push(chunk))
+        .once('end', () => {
+          resolve(chunks.map(chunk => chunk.toString('utf8')).join(''));
+          clientSession.close();
+        });
+    })
+      .once('aborted', fail)
+      .once('close', fail)
+      .once('error', fail);
+  });
+}
+
+/**
+ * Helper to start a server with HTTP/2 support.
+ * Returns stop function to handle server and dns cleanup after tests.
+ *
+ * Tests requests can be made to foo.example.org:3456
+ *
+ * @param {object} options - Additional http2 server options.
+ * @returns {Promise<(function(): void)|*>} callback
+ */
+async function startHttp2Server(options = {}) {
+  // disabling to avoid UNABLE_TO_VERIFY_LEAF_SIGNATURE for tests
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+  const servers = await createServersAsync({
+    http2: {
+      port: 3456,
+      root: path.join(__dirname, 'fixtures'),
+      key: 'example-org-key.pem',
+      cert: 'example-org-cert.pem',
+      ...options
+    },
+    handler: (req, res) => {
+      const { httpVersion } = req;
+      const { socket: { alpnProtocol } } = httpVersion === '2.0' ? req.stream.session : req;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        alpnProtocol,
+        httpVersion
+      }));
+    }
+  });
+
+  evilDNS.add('foo.example.org', '0.0.0.0');
+
+  return function stop() {
+    servers && servers.http2 && servers.http2.close();
+    evilDNS.clear();
+    delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  };
 }
 
 test('only http', function (t) {
@@ -142,6 +213,28 @@ test('only https', function (t) {
     t.equals(typeof servers.https, 'object');
     t.equals(servers.https.timeout, time);
     servers.https.close();
+  });
+});
+
+test('only http2', function (t) {
+  t.plan(4);
+  var time = 4000000;
+  createServers({
+    log: console.log,
+    http2: {
+      timeout: time,
+      port: 3456,
+      root: path.join(__dirname, 'fixtures'),
+      key: 'example-org-key.pem',
+      cert: 'example-org-cert.pem'
+    },
+    handler: fend
+  }, function (err, servers) {
+    t.error(err);
+    t.equals(typeof servers, 'object');
+    t.equals(typeof servers.http2, 'object');
+    t.equals(servers.http2.timeout, time);
+    servers.http2.close();
   });
 });
 
@@ -442,6 +535,50 @@ test('multiple https servers', async function (t) {
       servers.https instanceof Array ? servers.https : [servers.https];
     toClose.forEach(server => server.close());
     evilDNS.clear();
+  }
+});
+
+test('supports http2-only requests', async function (t) {
+  t.plan(2);
+  const url = 'https://foo.example.org:3456/';
+
+  let stopServer;
+  try {
+    stopServer = await startHttp2Server({});
+
+    const httpsResponse = await download(url);
+    t.ok(httpsResponse.includes('Unknown ALPN Protocol'));
+
+    const response = JSON.parse(await download2(url));
+    t.equals(response.httpVersion, '2.0');
+
+  } catch (err) {
+    t.error(err);
+  } finally {
+    stopServer && stopServer();
+  }
+});
+
+test('supports http2 and https requests', async function (t) {
+  t.plan(2);
+  const url = 'https://foo.example.org:3456/';
+
+  let stopServer;
+  try {
+    stopServer = await startHttp2Server({
+      allowHTTP1: true
+    });
+
+    const httpsResponse = JSON.parse(await download(url));
+    t.equals(httpsResponse.httpVersion, '1.1');
+
+    const response = JSON.parse(await download2(url));
+    t.equals(response.httpVersion, '2.0');
+
+  } catch (err) {
+    t.error(err);
+  } finally {
+    stopServer && stopServer();
   }
 });
 


### PR DESCRIPTION
This adds the ability to set an `http2` config property for setting up HTTP/2 servers.